### PR TITLE
Add link to repository to extension metadata

### DIFF
--- a/vss-extension.dev.json
+++ b/vss-extension.dev.json
@@ -2,6 +2,13 @@
 	"id": "sarif-viewer-build-tab-dev",
 	"name": "Sarif Viewer Build Tab DEV",
 	"public": false,
+	"repository": {
+		"type": "git",
+		"uri": "https://github.com/microsoft/sarif-azuredevops-extension"
+	},
+	"CustomerQnASupport": {
+		"enableqna":"true"
+	},
 	"contributions": [
 		{
 			"id": "sariftools.sarif-viewer-build-tab",

--- a/vss-extension.prod.json
+++ b/vss-extension.prod.json
@@ -2,6 +2,13 @@
 	"id": "sarif-viewer-build-tab",
 	"name": "Sarif Viewer Build Tab",
 	"public": true,
+	"repository": {
+		"type": "git",
+		"uri": "https://github.com/microsoft/sarif-azuredevops-extension"
+	},
+	"CustomerQnASupport": {
+		"enableqna":"true"
+	},
 	"contributions": [
 		{
 			"id": "sariftools.sarif-viewer-build-tab",


### PR DESCRIPTION
Add link to repository to extension metadata to improve discoverability of source code.

By default Q & A section would redirect to GitHub issues if a GitHub repository link is available. Since there's already an existing Q & A section I disabled this feature to keep the existing entries.